### PR TITLE
初回ユーザー登録&ユーザーに紐づいた好きなもの登録

### DIFF
--- a/app/Http/Controllers/BotManController.php
+++ b/app/Http/Controllers/BotManController.php
@@ -12,22 +12,9 @@ class BotManController extends Controller
     /**
      * Place your BotMan logic here.
      */
-    public function handle(Request $request)
+    public function handle()
     {
-
-        $slack_id = $request->input('event.user');
-        $user = new User;
-        $user->slack_id = $slack_id;
-        $user->user_name = 'テスト';
-        $user->introduced_count = 0;
-        $user->introduced_last_time = false;
-
-        logger($slack_id);
-
-//        $user->save();
-
         $botman = app('botman');
-
         $botman->listen();
     }
 

--- a/app/Item.php
+++ b/app/Item.php
@@ -6,5 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Item extends Model
 {
-    //
+    public function user()
+    {
+        return $this->belongsTo('App\User');
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -10,6 +10,11 @@ class User extends Authenticatable
 {
     use Notifiable;
 
+    public function items()
+    {
+        return $this->hasMany('App\Item');
+    }
+
     /**
      * The attributes that are mass assignable.
      *

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "doctrine/dbal": "^2.10",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "5.7.*",
-        "laravel/tinker": "^1.0"
+        "laravel/tinker": "^1.0",
+        "vluzrmos/slack-api": "^0.4.8"
     },
     "require-dev": {
         "beyondcode/laravel-dump-server": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ddd774b070e33901c2ac539e69d27b60",
+    "content-hash": "e33973b31cadd6e082ad4648088b1e58",
     "packages": [
         {
             "name": "botman/botman",
@@ -4030,6 +4030,53 @@
                 "environment"
             ],
             "time": "2018-07-29T20:33:41+00:00"
+        },
+        {
+            "name": "vluzrmos/slack-api",
+            "version": "v0.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vluzrmos/laravel-slack-api.git",
+                "reference": "8213d8db19be6546fac0db5256aad1cfdfac7fae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vluzrmos/laravel-slack-api/zipball/8213d8db19be6546fac0db5256aad1cfdfac7fae",
+                "reference": "8213d8db19be6546fac0db5256aad1cfdfac7fae",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "~5.3|~6.0",
+                "illuminate/cache": "~5.0",
+                "illuminate/support": "~5.0",
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Vluzrmos\\": "src/Vluzrmos/"
+                },
+                "files": [
+                    "src/Vluzrmos/SlackApi/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "DBAD"
+            ],
+            "authors": [
+                {
+                    "name": "Vagner do Carmo",
+                    "email": "vluzrmos@gmail.com"
+                }
+            ],
+            "description": "Wrapper for Slack.com WEB API.",
+            "keywords": [
+                "laravel",
+                "lumen",
+                "slack"
+            ],
+            "time": "2016-10-22T16:34:17+00:00"
         },
         {
             "name": "zendframework/zend-escaper",

--- a/config/app.php
+++ b/config/app.php
@@ -160,6 +160,9 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
         App\Providers\BotMan\DriverServiceProvider::class,
+
+        // slack-api
+        Vluzrmos\SlackApi\SlackApiServiceProvider::class,
     ],
 
     /*
@@ -209,6 +212,19 @@ return [
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
 
+        // slack-api
+        'SlackApi'              => Vluzrmos\SlackApi\Facades\SlackApi::class,
+        'SlackChannel'          => Vluzrmos\SlackApi\Facades\SlackChannel::class,
+        'SlackChat'             => Vluzrmos\SlackApi\Facades\SlackChat::class,
+        'SlackGroup'            => Vluzrmos\SlackApi\Facades\SlackGroup::class,
+        'SlackFile'             => Vluzrmos\SlackApi\Facades\SlackFile::class,
+        'SlackSearch'           => Vluzrmos\SlackApi\Facades\SlackSearch::class,
+        'SlackInstantMessage'   => Vluzrmos\SlackApi\Facades\SlackInstantMessage::class,
+        'SlackUser'             => Vluzrmos\SlackApi\Facades\SlackUser::class,
+        'SlackStar'             => Vluzrmos\SlackApi\Facades\SlackStar::class,
+        'SlackUserAdmin'        => Vluzrmos\SlackApi\Facades\SlackUserAdmin::class,
+        'SlackRealTimeMessage'  => Vluzrmos\SlackApi\Facades\SlackRealTimeMessage::class,
+        'SlackTeam'             => Vluzrmos\SlackApi\Facades\SlackTeam::class,
     ],
 
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,8 @@ return [
         'secret' => env('STRIPE_SECRET'),
     ],
 
+    'slack' => [
+        'token' => env('SLACK_TOKEN')
+    ]
+
 ];

--- a/database/migrations/2020_08_05_045628_add_user_id_to_items.php
+++ b/database/migrations/2020_08_05_045628_add_user_id_to_items.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUserIdToItems extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->unsignedInteger('user_id');
+            $table->foreign('user_id')->references('id')->on('users')
+                  ->onUpdate('cascade')
+                  ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->dropColumn('user_id');
+        });
+    }
+}

--- a/routes/botman.php
+++ b/routes/botman.php
@@ -1,6 +1,7 @@
 <?php
 use App\Http\Controllers\BotManController;
-
+use App\User;
+use App\Item;
 
 $botman = resolve('botman');
 
@@ -8,8 +9,33 @@ $botman->hears('Hi', function ($bot) {
     $bot->reply('Hello!');
 });
 
-$botman->hears('好きなもの：{item}', function ($bot, $name) {
-    $bot->reply('あなたの好きなものは' . $name . 'ですね');
+$botman->hears('好きなもの：{item}', function ($bot, $item_content) {
+    // slackのリクエストから、メッセージを送信したユーザーのslack_idを取得
+    $request = request();
+    $slack_id = $request['event']['user'];
+
+    // slack_idを元に、WebAPI経由でユーザー名を取得
+    // "laravel-slack-api"パッケージを利用
+    // 参考: https://github.com/vluzrmos/laravel-slack-api
+    $user_info = SlackUser::info($slack_id); // APIにリクエストを送信
+    $user_info = json_decode(json_encode($user_info, JSON_PRETTY_PRINT), true); //単なる文字列→JSON化→PHPの連想配列化
+    $user_name = $user_info['user']['name'];
+
+    // まだ登録されていないユーザーなら登録。登録済みのユーザーはfind。
+    // 参考: https://readouble.com/laravel/5.7/ja/eloquent.html
+    $user = User::firstOrNew(['slack_id' => $slack_id], ['name' => $user_name]);
+    if (!$user->exists) {
+        $user->slack_id = $slack_id;
+        $user->save();
+    }
+
+
+    // 上記で呼び出しor作成したユーザーに紐づいたアイテムを作成
+    $item = new Item();
+    $item->content = $item_content;
+    $user->items()->save($item);
+
+    $bot->reply("好きなものとして $item_content が追加されました！");
 });
 
 $botman->hears('Start conversation', BotManController::class.'@startConversation');


### PR DESCRIPTION
# 実装の概要
#9  の実装
## 実装の詳細
- [x] itemにuser_idを追加して関連付ける
- [x] "好きなもの：{item}"と送信した際に反応
- [x] Requestから、slack_idとユーザー名を取り出して、初めてのユーザーなら登録。既にあればfind。
- [x] ユーザーに紐づいた好きなものを作成
- [x] "好きなものとして、$itemが登録されました！"と返信