### PR TITLE
外部キー制約によるエラーでmigrateが落ちていた問題を修正

### DIFF
--- a/database/migrations/2020_07_08_072508_add_column_to_items_table.php
+++ b/database/migrations/2020_07_08_072508_add_column_to_items_table.php
@@ -20,8 +20,8 @@ class AddColumnToItemsTable extends Migration
             $table->unsignedInteger('theme_id');
             $table->foreign('theme_id')->references('id')->on('themes');
             // 簡潔なメソッド、らしいけどエラーで動かず。
-//            $table->foreignId('user_id')->constrained();
-//            $table->foreignId('theme_id')->constrained();
+            // $table->foreign('user_id')->constrained();
+            // $table->foreign('theme_id')->constrained();
         });
     }
 
@@ -32,8 +32,12 @@ class AddColumnToItemsTable extends Migration
      */
     public function down()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::table('items', function (Blueprint $table) {
+            $table->dropForeign('items_theme_id_foreign');
+            $table->dropForeign('items_user_id_foreign');
             $table->dropColumn(['theme_id', 'user_id']);
         });
+        Schema::enableForeignKeyConstraints();
     }
 }

--- a/database/migrations/2020_08_03_073202_remove_relation_from_items.php
+++ b/database/migrations/2020_08_03_073202_remove_relation_from_items.php
@@ -13,9 +13,13 @@ class RemoveRelationFromItems extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::table('items', function (Blueprint $table) {
+            $table->dropForeign('items_theme_id_foreign');
+            $table->dropForeign('items_user_id_foreign');
             $table->dropColumn(['theme_id', 'user_id']);
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**


### PR DESCRIPTION
## 起きていた問題 & それを確認した状況
cloneしたばかりの状態で `$ php artisan migrate` を実行すると、  
itemsテーブルでされようとしている`dropColumn(['theme_id', 'user_id'])`のところで、  
参照制約により削除できずにMySQL上でエラーが起きていた。

## やったこと
`dropColumn(['theme_id', 'user_id'])` を走らせているところを、

1. 参照制約の無効化
2. 外部キーの削除
3. `dropColumn(['theme_id', 'user_id'])` 
4. 参照制約の有効化

という風に書き換えた。

## 動作確認
- [ ] cloneしたばかりの状態で `$ php artisan migrate` が実行に成功しているか