### PR TITLE
editorConfig追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# The JSON files contain newlines inconsistently
+[*.json]
+insert_final_newline = ignore
+
+# Minified JavaScript files shouldn't be changed
+[**.min.js]
+indent_style = ignore
+insert_final_newline = ignore
+
+# Makefiles always use tabs for indentation
+[Makefile]
+indent_style = tab
+
+# Batch files use tabs for indentation
+[*.bat]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+


### PR DESCRIPTION
## したかったこと
インデントの設定等を、開発者ごとのコーディング環境の設定に左右されないようにした。

### editorConfigとは？
使っているIDE or エディタが、
- PhpStormの場合は[こちら](https://pleiades.io/help/phpstorm/configuring-code-style.html#editorconfig)
- VSCodeの場合は[こちら](https://qiita.com/naru0504/items/82f09881abaf3f4dc171) **※設定が必要**

## 動作確認
- [ ] インデントの設定がspace 4sizeになっているか